### PR TITLE
Fix missing QTWEBKIT_VERSION_STR on Mac

### DIFF
--- a/src/peb.h
+++ b/src/peb.h
@@ -27,6 +27,7 @@
 #include <QWebView>
 #include <QWebFrame>
 #include <QWebElement>
+#include <QtWebKit>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>


### PR DESCRIPTION
Include QtWebKit header in peb.h, fixes the problem with missing
QTWEBKIT_VERSION_STR constant and makes possible to be build on Mac.
